### PR TITLE
build(mac): minimal support updates for local builds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,6 +7,12 @@ These steps cover: decompressing the ROM, running the recompiler and finally bui
 ## 1. Building the Bomberman 64 decompilation
 You will need a decompressed ROM. Build the project at https://github.com/Bomberhackers/bm64 which will generate a decompressed ROM from an existing locally dumped BM64 US ROM.
 
+Place the decompressed ROM in the repository root as:
+
+```bash
+bm64.decomp.us.z64
+```
+
 ## 2. Clone the Bomberman 64 Recompiled Repository
 This project makes use of submodules so you will need to clone the repository with the `--recurse-submodules` flag.
 
@@ -26,6 +32,16 @@ For Linux the instructions for Ubuntu are provided, but you can find the equival
 sudo apt-get install cmake ninja libsdl2-dev libgtk-3-dev lld llvm clang-15
 ```
 
+### macOS
+For macOS, install dependencies with Homebrew:
+
+```bash
+brew install cmake ninja sdl2 freetype llvm lld
+python3 -m pip install --user macholib
+```
+
+`macholib` is required by the macOS linker wrapper used by this project.
+
 ### Windows
 You will need to install [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/).
 In the setup process you'll need to select the following options and tools for installation:
@@ -33,7 +49,7 @@ In the setup process you'll need to select the following options and tools for i
 - C++ Clang Compiler for Windows
 - C++ CMake tools for Windows
 
-The other tool necessary will be `make` which can be installe via [Chocolatey](https://chocolatey.org/):
+The other tool necessary will be `make` which can be installed via [Chocolatey](https://chocolatey.org/):
 ```bash
 choco install make
 ```
@@ -58,12 +74,14 @@ If you prefer the command line or you're on a Unix platform you can build the pr
 
 ```bash
 cmake -S . -B build-cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -G Ninja -DCMAKE_BUILD_TYPE=Release # or Debug if you want to debug
-cmake --build build-cmake --target BM64Recompiled -j$(nproc) --config Release # or Debug
+cmake --build build-cmake --target BM64Recompiled --config Release --parallel # or Debug
 ```
 
 ## 6. Success
 
-Voilà! You should now have a `BM64Recompiled` executable in the build directory! If you used Visual Studio this will be `out/build/x64-[Configuration]` and if you used the provided CMake commands then this will be `build-cmake`. You will need to run the executable out of the root folder of this project or copy the assets folder to the build folder to run it.
+Voilà! You should now have a BM64Recompiled executable in the build directory! If you used Visual Studio this will be `out/build/x64-[Configuration]` and if you used the provided CMake commands then this will be `build-cmake`.
 
-> [!IMPORTANT]  
+On macOS, the output is `build-cmake/BM64Recompiled.app`.
+
+> [!IMPORTANT]
 > In the game itself, you should be using a standard ROM, not the decompressed one.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,20 @@ endif()
 
 if (APPLE)
     enable_language(OBJC OBJCXX)
+
+    execute_process(
+        COMMAND /usr/bin/python3 -c "import macholib"
+        RESULT_VARIABLE MACHOLIB_IMPORT_RESULT
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if (NOT MACHOLIB_IMPORT_RESULT EQUAL 0)
+        message(WARNING
+            "Python package 'macholib' was not found for /usr/bin/python3. "
+            "The custom macOS linker wrapper at .github/macos/ld64 will fail at link time without it. "
+            "Install it with: python3 -m pip install --user macholib"
+        )
+    endif()
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -113,12 +127,43 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/RecompiledPatches/patches.c PROP
 
 # Build patches elf
 if(NOT DEFINED PATCHES_C_COMPILER)
-    set(PATCHES_C_COMPILER clang)
+    if (APPLE)
+        if (EXISTS "/opt/local/bin/clang-mp-18")
+            set(PATCHES_C_COMPILER "/opt/local/bin/clang-mp-18")
+        elseif (EXISTS "/opt/homebrew/opt/llvm/bin/clang")
+            set(PATCHES_C_COMPILER "/opt/homebrew/opt/llvm/bin/clang")
+        elseif (EXISTS "/usr/local/opt/llvm/bin/clang")
+            set(PATCHES_C_COMPILER "/usr/local/opt/llvm/bin/clang")
+        else()
+            set(PATCHES_C_COMPILER clang)
+        endif()
+    else()
+        set(PATCHES_C_COMPILER clang)
+    endif()
 endif()
 
 if(NOT DEFINED PATCHES_LD)
-    set(PATCHES_LD ld.lld)
+    if (APPLE)
+        if (EXISTS "/opt/local/bin/ld.lld-mp-18")
+            set(PATCHES_LD "/opt/local/bin/ld.lld-mp-18")
+        elseif (EXISTS "/opt/homebrew/opt/lld/bin/ld.lld")
+            set(PATCHES_LD "/opt/homebrew/opt/lld/bin/ld.lld")
+        elseif (EXISTS "/opt/homebrew/opt/llvm/bin/ld.lld")
+            set(PATCHES_LD "/opt/homebrew/opt/llvm/bin/ld.lld")
+        elseif (EXISTS "/usr/local/opt/lld/bin/ld.lld")
+            set(PATCHES_LD "/usr/local/opt/lld/bin/ld.lld")
+        elseif (EXISTS "/usr/local/opt/llvm/bin/ld.lld")
+            set(PATCHES_LD "/usr/local/opt/llvm/bin/ld.lld")
+        else()
+            set(PATCHES_LD ld.lld)
+        endif()
+    else()
+        set(PATCHES_LD ld.lld)
+    endif()
 endif()
+
+message(STATUS "PATCHES_C_COMPILER = ${PATCHES_C_COMPILER}")
+message(STATUS "PATCHES_LD = ${PATCHES_LD}")
 
 add_custom_target(PatchesBin
     COMMAND ${CMAKE_COMMAND} -E env CC=${PATCHES_C_COMPILER} LD=${PATCHES_LD} make

--- a/patches/Makefile
+++ b/patches/Makefile
@@ -5,7 +5,7 @@ LD      ?= ld.lld
 
 CFLAGS   := -target mips -mips2 -mabi=32 -O0 -G0 -mno-abicalls -mno-odd-spreg -mno-check-zero-division \
 			-fomit-frame-pointer -ffast-math -fno-unsafe-math-optimizations -fno-builtin-memset \
-			-Wall -Wextra -Wno-incompatible-library-redeclaration -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-variable -Wno-unused-but-set-variable -Wno-missing-braces -Wno-unsupported-floating-point-opt -Wno-switch -D_MIPS_SZLONG=32
+			-Wall -Wextra -Wno-incompatible-library-redeclaration -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-variable -Wno-unused-but-set-variable -Wno-missing-braces -Wno-unsupported-floating-point-opt -Wno-switch -Wno-incompatible-pointer-types -Wno-int-conversion -D_MIPS_SZLONG=32
 CPPFLAGS := -nostdinc -DF3DEX_GBI -D_LANGUAGE_C -DMIPS -I dummy_headers -I ../lib/sf64/include -I ../lib/sf64/include/libultra -I ../lib/sf64/src -I ../lib/rt64/include -I ../lib/N64ModernRuntime/ultramodern/include -I ../lib/N64ModernRuntime/ultramodern/include/ultramodern
 LDFLAGS  := -nostdlib -T patches.ld -T syms.ld -Map patches.map --unresolved-symbols=ignore-all --emit-relocs
 


### PR DESCRIPTION
## Summary
- add minimal macOS dependency/build notes to BUILDING.md
- auto-detect common macOS patch toolchain paths in CMake (Homebrew/MacPorts)
- make patch compilation tolerant of modern LLVM pointer conversion diagnostics

## Validation
- verified CMake configure auto-selects Homebrew LLVM/LLD for PATCHES_C_COMPILER/PATCHES_LD
- verified PatchesBin target builds with default flags on macOS
- verified full local macOS app build path previously succeeds with these changes