### PR TITLE
Add Multiple Controller Support

### DIFF
--- a/assets/config_menu/controls.rml
+++ b/assets/config_menu/controls.rml
@@ -9,7 +9,7 @@
                     class="button"
                     data-class-button--success="selected_port == 0"
                     data-event-click="select_port(0)"
-                    style="min-width: 48dp;"
+                    data-attr-style="port_0_style"
                 >
                     <div class="button__label">P1</div>
                 </button>
@@ -17,7 +17,7 @@
                     class="button"
                     data-class-button--success="selected_port == 1"
                     data-event-click="select_port(1)"
-                    style="min-width: 48dp;"
+                    data-attr-style="port_1_style"
                 >
                     <div class="button__label">P2</div>
                 </button>
@@ -25,7 +25,7 @@
                     class="button"
                     data-class-button--success="selected_port == 2"
                     data-event-click="select_port(2)"
-                    style="min-width: 48dp;"
+                    data-attr-style="port_2_style"
                 >
                     <div class="button__label">P3</div>
                 </button>
@@ -33,18 +33,18 @@
                     class="button"
                     data-class-button--success="selected_port == 3"
                     data-event-click="select_port(3)"
-                    style="min-width: 48dp;"
+                    data-attr-style="port_3_style"
                 >
                     <div class="button__label">P4</div>
                 </button>
             </div>
             <!-- Port mode selector -->
-            <div class="config__header" style="justify-content: center; gap: 8dp; margin-bottom: 4dp;">
+            <div class="config__header" style="justify-content: center; gap: 8dp; margin-bottom: 4dp; align-items: center;">
                 <button
                     class="button"
                     data-class-button--error="port_mode == 'Off'"
                     data-event-click="set_port_mode('Off')"
-                    style="min-width: 64dp;"
+                    data-attr-style="port_mode == 'Off' ? 'min-width: 64dp; opacity: 1.0;' : 'min-width: 64dp; opacity: 0.5;'"
                 >
                     <div class="button__label">Off</div>
                 </button>
@@ -52,7 +52,7 @@
                     class="button"
                     data-class-button--success="port_mode == 'Keyboard'"
                     data-event-click="set_port_mode('Keyboard')"
-                    style="min-width: 80dp;"
+                    data-attr-style="port_mode == 'Keyboard' ? 'min-width: 80dp; opacity: 1.0;' : 'min-width: 80dp; opacity: 0.5;'"
                 >
                     <div class="button__label">Keyboard</div>
                 </button>
@@ -60,41 +60,26 @@
                     class="button"
                     data-class-button--success="port_mode == 'Controller'"
                     data-event-click="set_port_mode('Controller')"
-                    style="min-width: 80dp;"
+                    data-attr-style="port_mode == 'Controller' ? 'min-width: 80dp; opacity: 1.0;' : 'min-width: 80dp; opacity: 0.5;'"
                 >
                     <div class="button__label">Controller</div>
                 </button>
-                <label
-                    data-if="port_mode == 'Controller'"
-                    style="margin-left: 8dp; color: #aaa; font-size: 14dp;"
-                >{{assigned_controller_name}}</label>
-            </div>
-            <div class="config__header">
-                <div class="config__header-left">
-                    <button
-                        class="toggle"
-                        id="cont_kb_toggle"
-                        data-class-toggle--checked="input_device_is_keyboard"
-                        onclick="toggle_input_device"
-                        style="nav-down: #input_row_button_0_0; nav-up: #tab_controls"
-                    >
-                        <div class="toggle__border" />
-                        <div class="toggle__floater" />
-                        <div class="toggle__icons">
-                            <div class="toggle__icon toggle__icon--left"><div>␼</div></div>
-                            <div class="toggle__icon toggle__icon--right"><div>␽</div></div>
-                        </div>
-                    </button>
-                </div>
-                <div>
-                    <button
-                        class="button button--warning"
-                        style="nav-down:#input_row_button_0_0"
-                        data-event-click="reset_input_bindings_to_defaults"
-                    >
-                        <div class="button__label">Reset to defaults</div>
-                    </button>
-                </div>
+                <select
+                    class="config-option-dropdown__select"
+                    id="port_controller_select"
+                    data-value="port_controller_index"
+                    onchange="port_controller_changed"
+                    style="min-width: 300dp; margin-left: 8dp; flex: 0 1 auto; height: auto; padding: 23dp;"
+                >
+                    <option data-for="name, i : connected_controller_names" data-attr-value="i">{{name}}</option>
+                </select>
+                <button
+                    class="button button--warning"
+                    style="nav-down:#input_row_button_0_0; margin-left: 8dp;"
+                    data-event-click="reset_input_bindings_to_defaults"
+                >
+                    <div class="button__label">Reset to defaults</div>
+                </button>
             </div>
             <div class="config__wrapper input-config">
                 <div class="input-config__horizontal-split">
@@ -107,7 +92,7 @@
                                     data-for="input_bindings, i : inputs.array"
                                     data-event-mouseover="set_input_row_focus(i)"
                                     data-class-control-option--active="get_input_enum_name(i)==cur_input_row"
-                                    data-if="!input_device_is_keyboard || (get_input_enum_name(i) != 'TOGGLE_MENU' && get_input_enum_name(i) != 'ACCEPT_MENU' && get_input_enum_name(i) != 'APPLY_MENU')"
+                                    data-if="(!is_multiplayer_port || get_input_enum_name(i) == 'A' || get_input_enum_name(i) == 'B' || get_input_enum_name(i) == 'START' || get_input_enum_name(i) == 'X_AXIS_NEG' || get_input_enum_name(i) == 'X_AXIS_POS' || get_input_enum_name(i) == 'Y_AXIS_NEG' || get_input_enum_name(i) == 'Y_AXIS_POS') && (!input_device_is_keyboard || (get_input_enum_name(i) != 'TOGGLE_MENU' && get_input_enum_name(i) != 'ACCEPT_MENU' && get_input_enum_name(i) != 'APPLY_MENU'))"
                                 >
                                     <label
                                         class="control-option__label"
@@ -121,7 +106,7 @@
                                             data-event-click="set_input_binding(i,j)"
                                             class="prompt-font control-option__binding"
                                             data-attr-bind-slot="j"
-                                            data-attr-style="i == 0 ? 'nav-up:#cont_kb_toggle' : 'nav-up:auto'"
+                                            data-attr-style="i == 0 ? 'nav-up:#tab_controls' : 'nav-up:auto'"
                                         >
                                             <div class="control-option__binding-recording">
                                                 <div class="control-option__binding-circle" />
@@ -138,7 +123,7 @@
                                         data-event-focus="set_input_row_focus(i)"
                                         data-event-click="clear_input_bindings(i)"
                                         class="icon-button icon-button--error"
-                                        data-attr-style="i == 0 ? 'nav-up:#cont_kb_toggle' : 'nav-up:auto'"
+                                        data-attr-style="i == 0 ? 'nav-up:#tab_controls' : 'nav-up:auto'"
                                     >
                                         <svg src="icons/Trash.svg" />
                                     </button>
@@ -148,7 +133,7 @@
                                         data-event-focus="set_input_row_focus(i)"
                                         data-event-click="reset_single_input_binding_to_default(i)"
                                         class="icon-button icon-button--error"
-                                        data-attr-style="i == 0 ? 'nav-up:#cont_kb_toggle' : 'nav-up:auto'"
+                                        data-attr-style="i == 0 ? 'nav-up:#tab_controls' : 'nav-up:auto'"
                                     >
                                         <svg src="icons/Reset.svg" />
                                     </button>

--- a/assets/config_menu/controls.rml
+++ b/assets/config_menu/controls.rml
@@ -3,6 +3,72 @@
     </head>
     <body>
         <form class="config__form" data-attr-cur-input="cur_input_row" data-attr-cur-binding-slot="active_binding_slot">
+            <!-- Port selector -->
+            <div class="config__header" style="justify-content: center; gap: 8dp; margin-bottom: 4dp;">
+                <button
+                    class="button"
+                    data-class-button--success="selected_port == 0"
+                    data-event-click="select_port(0)"
+                    style="min-width: 48dp;"
+                >
+                    <div class="button__label">P1</div>
+                </button>
+                <button
+                    class="button"
+                    data-class-button--success="selected_port == 1"
+                    data-event-click="select_port(1)"
+                    style="min-width: 48dp;"
+                >
+                    <div class="button__label">P2</div>
+                </button>
+                <button
+                    class="button"
+                    data-class-button--success="selected_port == 2"
+                    data-event-click="select_port(2)"
+                    style="min-width: 48dp;"
+                >
+                    <div class="button__label">P3</div>
+                </button>
+                <button
+                    class="button"
+                    data-class-button--success="selected_port == 3"
+                    data-event-click="select_port(3)"
+                    style="min-width: 48dp;"
+                >
+                    <div class="button__label">P4</div>
+                </button>
+            </div>
+            <!-- Port mode selector -->
+            <div class="config__header" style="justify-content: center; gap: 8dp; margin-bottom: 4dp;">
+                <button
+                    class="button"
+                    data-class-button--error="port_mode == 'Off'"
+                    data-event-click="set_port_mode('Off')"
+                    style="min-width: 64dp;"
+                >
+                    <div class="button__label">Off</div>
+                </button>
+                <button
+                    class="button"
+                    data-class-button--success="port_mode == 'Keyboard'"
+                    data-event-click="set_port_mode('Keyboard')"
+                    style="min-width: 80dp;"
+                >
+                    <div class="button__label">Keyboard</div>
+                </button>
+                <button
+                    class="button"
+                    data-class-button--success="port_mode == 'Controller'"
+                    data-event-click="set_port_mode('Controller')"
+                    style="min-width: 80dp;"
+                >
+                    <div class="button__label">Controller</div>
+                </button>
+                <label
+                    data-if="port_mode == 'Controller'"
+                    style="margin-left: 8dp; color: #aaa; font-size: 14dp;"
+                >{{assigned_controller_name}}</label>
+            </div>
             <div class="config__header">
                 <div class="config__header-left">
                     <button

--- a/include/recomp_input.h
+++ b/include/recomp_input.h
@@ -84,6 +84,25 @@ namespace recomp {
         COUNT
     };
 
+    enum class ControllerPortMode {
+        Off,
+        Keyboard,
+        Controller,
+        OptionCount
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(recomp::ControllerPortMode, {
+        {recomp::ControllerPortMode::Off, "Off"},
+        {recomp::ControllerPortMode::Keyboard, "Keyboard"},
+        {recomp::ControllerPortMode::Controller, "Controller"}
+    });
+
+    constexpr int max_ports = 4;
+
+    ControllerPortMode get_port_mode(int port);
+    void set_port_mode(int port, ControllerPortMode mode);
+    int get_port_count();
+
     void start_scanning_input(InputDevice device);
     void stop_scanning_input();
     void finish_scanning_input(InputField scanned_field);
@@ -150,6 +169,7 @@ namespace recomp {
 
     extern const DefaultN64Mappings default_n64_keyboard_mappings;
     extern const DefaultN64Mappings default_n64_controller_mappings;
+    const DefaultN64Mappings& get_default_keyboard_mappings_for_port(int port);
 
     constexpr size_t bindings_per_input = 2;
 
@@ -158,7 +178,9 @@ namespace recomp {
     const std::string& get_input_enum_name(GameInput input);
     GameInput get_input_from_enum_name(const std::string_view name);
     InputField& get_input_binding(GameInput input, size_t binding_index, InputDevice device);
+    InputField& get_input_binding(GameInput input, size_t binding_index, InputDevice device, int port);
     void set_input_binding(GameInput input, size_t binding_index, InputDevice device, InputField value);
+    void set_input_binding(GameInput input, size_t binding_index, InputDevice device, InputField value, int port);
 
     bool get_n64_input(int controller_num, uint16_t* buttons_out, float* x_out, float* y_out);
     void set_rumble(int controller_num, bool);

--- a/include/recomp_input.h
+++ b/include/recomp_input.h
@@ -188,7 +188,8 @@ namespace recomp {
     void handle_events();
 
     ultramodern::input::connected_device_info_t get_connected_device_info(int controller_num);
-    
+    std::string get_port_controller_name(int port);
+
     // Rumble strength ranges from 0 to 100.
     int get_rumble_strength();
     void set_rumble_strength(int strength);

--- a/include/recomp_input.h
+++ b/include/recomp_input.h
@@ -194,6 +194,9 @@ namespace recomp {
 
     ultramodern::input::connected_device_info_t get_connected_device_info(int controller_num);
     std::string get_port_controller_name(int port);
+    std::vector<std::string> get_connected_controller_names();
+    int get_port_controller_index(int port);
+    void assign_controller_to_port(int port, int controller_index);
 
     // Rumble strength ranges from 0 to 100.
     int get_rumble_strength();

--- a/include/recomp_input.h
+++ b/include/recomp_input.h
@@ -74,6 +74,11 @@ namespace recomp {
     float get_input_analog(const std::span<const recomp::InputField> fields);
     bool get_input_digital(const InputField& field);
     bool get_input_digital(const std::span<const recomp::InputField> fields);
+    // Per-port versions: for controller inputs, read only from the port's assigned gamepad
+    float get_input_analog_port(const InputField& field, int port);
+    float get_input_analog_port(const std::span<const recomp::InputField> fields, int port);
+    bool get_input_digital_port(const InputField& field, int port);
+    bool get_input_digital_port(const std::span<const recomp::InputField> fields, int port);
     void get_gyro_deltas(float* x, float* y);
     void get_mouse_deltas(float* x, float* y);
     void get_right_analog(float* x, float* y);

--- a/include/zelda_config.h
+++ b/include/zelda_config.h
@@ -15,9 +15,13 @@ namespace zelda64 {
     void save_config();
     
     void reset_input_bindings();
+    void reset_input_bindings(int port);
     void reset_cont_input_bindings();
+    void reset_cont_input_bindings(int port);
     void reset_kb_input_bindings();
+    void reset_kb_input_bindings(int port);
     void reset_single_input_binding(recomp::InputDevice device, recomp::GameInput input);
+    void reset_single_input_binding(recomp::InputDevice device, recomp::GameInput input, int port);
 
     std::filesystem::path get_app_folder_path();
     

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -270,72 +270,91 @@ bool load_general_config(const std::filesystem::path& path) {
     return true;
 }
 
-void assign_mapping(recomp::InputDevice device, recomp::GameInput input, const std::vector<recomp::InputField>& value) {
+void assign_mapping(recomp::InputDevice device, recomp::GameInput input, const std::vector<recomp::InputField>& value, int port = 0) {
     for (size_t binding_index = 0; binding_index < std::min(value.size(), recomp::bindings_per_input); binding_index++) {
-        recomp::set_input_binding(input, binding_index, device, value[binding_index]);
+        recomp::set_input_binding(input, binding_index, device, value[binding_index], port);
     }
 };
 
 // same as assign_mapping, except will clear unassigned bindings if not in value
-void assign_mapping_complete(recomp::InputDevice device, recomp::GameInput input, const std::vector<recomp::InputField>& value) {
+void assign_mapping_complete(recomp::InputDevice device, recomp::GameInput input, const std::vector<recomp::InputField>& value, int port = 0) {
     for (size_t binding_index = 0; binding_index < recomp::bindings_per_input; binding_index++) {
         if (binding_index >= value.size()) {
-            recomp::set_input_binding(input, binding_index, device, recomp::InputField{});
+            recomp::set_input_binding(input, binding_index, device, recomp::InputField{}, port);
         } else {
-            recomp::set_input_binding(input, binding_index, device, value[binding_index]);
+            recomp::set_input_binding(input, binding_index, device, value[binding_index], port);
         }
     }
 };
 
-void assign_all_mappings(recomp::InputDevice device, const recomp::DefaultN64Mappings& values) {
-    assign_mapping_complete(device, recomp::GameInput::A, values.a);
-    assign_mapping_complete(device, recomp::GameInput::B, values.b);
-    assign_mapping_complete(device, recomp::GameInput::Z, values.z);
-    assign_mapping_complete(device, recomp::GameInput::START, values.start);
-    assign_mapping_complete(device, recomp::GameInput::DPAD_UP, values.dpad_up);
-    assign_mapping_complete(device, recomp::GameInput::DPAD_DOWN, values.dpad_down);
-    assign_mapping_complete(device, recomp::GameInput::DPAD_LEFT, values.dpad_left);
-    assign_mapping_complete(device, recomp::GameInput::DPAD_RIGHT, values.dpad_right);
-    assign_mapping_complete(device, recomp::GameInput::L, values.l);
-    assign_mapping_complete(device, recomp::GameInput::R, values.r);
-    assign_mapping_complete(device, recomp::GameInput::C_UP, values.c_up);
-    assign_mapping_complete(device, recomp::GameInput::C_DOWN, values.c_down);
-    assign_mapping_complete(device, recomp::GameInput::C_LEFT, values.c_left);
-    assign_mapping_complete(device, recomp::GameInput::C_RIGHT, values.c_right);
+void assign_all_mappings(recomp::InputDevice device, const recomp::DefaultN64Mappings& values, int port = 0) {
+    assign_mapping_complete(device, recomp::GameInput::A, values.a, port);
+    assign_mapping_complete(device, recomp::GameInput::B, values.b, port);
+    assign_mapping_complete(device, recomp::GameInput::Z, values.z, port);
+    assign_mapping_complete(device, recomp::GameInput::START, values.start, port);
+    assign_mapping_complete(device, recomp::GameInput::DPAD_UP, values.dpad_up, port);
+    assign_mapping_complete(device, recomp::GameInput::DPAD_DOWN, values.dpad_down, port);
+    assign_mapping_complete(device, recomp::GameInput::DPAD_LEFT, values.dpad_left, port);
+    assign_mapping_complete(device, recomp::GameInput::DPAD_RIGHT, values.dpad_right, port);
+    assign_mapping_complete(device, recomp::GameInput::L, values.l, port);
+    assign_mapping_complete(device, recomp::GameInput::R, values.r, port);
+    assign_mapping_complete(device, recomp::GameInput::C_UP, values.c_up, port);
+    assign_mapping_complete(device, recomp::GameInput::C_DOWN, values.c_down, port);
+    assign_mapping_complete(device, recomp::GameInput::C_LEFT, values.c_left, port);
+    assign_mapping_complete(device, recomp::GameInput::C_RIGHT, values.c_right, port);
 
-    assign_mapping_complete(device, recomp::GameInput::X_AXIS_NEG, values.analog_left);
-    assign_mapping_complete(device, recomp::GameInput::X_AXIS_POS, values.analog_right);
-    assign_mapping_complete(device, recomp::GameInput::Y_AXIS_NEG, values.analog_down);
-    assign_mapping_complete(device, recomp::GameInput::Y_AXIS_POS, values.analog_up);
+    assign_mapping_complete(device, recomp::GameInput::X_AXIS_NEG, values.analog_left, port);
+    assign_mapping_complete(device, recomp::GameInput::X_AXIS_POS, values.analog_right, port);
+    assign_mapping_complete(device, recomp::GameInput::Y_AXIS_NEG, values.analog_down, port);
+    assign_mapping_complete(device, recomp::GameInput::Y_AXIS_POS, values.analog_up, port);
 
-    assign_mapping_complete(device, recomp::GameInput::TOGGLE_MENU, values.toggle_menu);
-    assign_mapping_complete(device, recomp::GameInput::ACCEPT_MENU, values.accept_menu);
-    assign_mapping_complete(device, recomp::GameInput::APPLY_MENU, values.apply_menu);
+    assign_mapping_complete(device, recomp::GameInput::TOGGLE_MENU, values.toggle_menu, port);
+    assign_mapping_complete(device, recomp::GameInput::ACCEPT_MENU, values.accept_menu, port);
+    assign_mapping_complete(device, recomp::GameInput::APPLY_MENU, values.apply_menu, port);
 };
 
 void zelda64::reset_input_bindings() {
-    assign_all_mappings(recomp::InputDevice::Keyboard, recomp::default_n64_keyboard_mappings);
-    assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings);
+    for (int p = 0; p < recomp::max_ports; p++) {
+        reset_input_bindings(p);
+    }
+}
+
+void zelda64::reset_input_bindings(int port) {
+    assign_all_mappings(recomp::InputDevice::Keyboard, recomp::get_default_keyboard_mappings_for_port(port), port);
+    assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings, port);
 }
 
 void zelda64::reset_cont_input_bindings() {
-    assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings);
+    reset_cont_input_bindings(0);
+}
+
+void zelda64::reset_cont_input_bindings(int port) {
+    assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings, port);
 }
 
 void zelda64::reset_kb_input_bindings() {
-    assign_all_mappings(recomp::InputDevice::Keyboard, recomp::default_n64_keyboard_mappings);
+    reset_kb_input_bindings(0);
+}
+
+void zelda64::reset_kb_input_bindings(int port) {
+    assign_all_mappings(recomp::InputDevice::Keyboard, recomp::get_default_keyboard_mappings_for_port(port), port);
 }
 
 void zelda64::reset_single_input_binding(recomp::InputDevice device, recomp::GameInput input) {
+    reset_single_input_binding(device, input, 0);
+}
+
+void zelda64::reset_single_input_binding(recomp::InputDevice device, recomp::GameInput input, int port) {
     assign_mapping_complete(
         device,
         input,
         recomp::get_default_mapping_for_input(
             device == recomp::InputDevice::Keyboard ?
-                recomp::default_n64_keyboard_mappings :
+                recomp::get_default_keyboard_mappings_for_port(port) :
                 recomp::default_n64_controller_mappings,
             input
-        )
+        ),
+        port
     );
 }
 
@@ -372,32 +391,43 @@ bool load_graphics_config(const std::filesystem::path& path) {
     return true;
 }
 
-void add_input_bindings(nlohmann::json& out, recomp::GameInput input, recomp::InputDevice device) {
+void add_input_bindings(nlohmann::json& out, recomp::GameInput input, recomp::InputDevice device, int port = 0) {
     const std::string& input_name = recomp::get_input_enum_name(input);
     nlohmann::json& out_array = out[input_name];
     out_array = nlohmann::json::array();
     for (size_t binding_index = 0; binding_index < recomp::bindings_per_input; binding_index++) {
-        out_array[binding_index] = recomp::get_input_binding(input, binding_index, device);
+        out_array[binding_index] = recomp::get_input_binding(input, binding_index, device, port);
     }
 };
 
 bool save_controls_config(const std::filesystem::path& path) {
     nlohmann::json config_json{};
 
-    config_json["keyboard"] = {};
-    config_json["controller"] = {};
+    nlohmann::json ports_array = nlohmann::json::array();
+    for (int p = 0; p < recomp::max_ports; p++) {
+        nlohmann::json port_json{};
 
-    for (size_t i = 0; i < recomp::get_num_inputs(); i++) {
-        recomp::GameInput cur_input = static_cast<recomp::GameInput>(i);
+        // Save mode
+        recomp::to_json(port_json["mode"], recomp::get_port_mode(p));
 
-        add_input_bindings(config_json["keyboard"], cur_input, recomp::InputDevice::Keyboard);
-        add_input_bindings(config_json["controller"], cur_input, recomp::InputDevice::Controller);
+        // Save bindings
+        port_json["keyboard"] = {};
+        port_json["controller"] = {};
+
+        for (size_t i = 0; i < recomp::get_num_inputs(); i++) {
+            recomp::GameInput cur_input = static_cast<recomp::GameInput>(i);
+            add_input_bindings(port_json["keyboard"], cur_input, recomp::InputDevice::Keyboard, p);
+            add_input_bindings(port_json["controller"], cur_input, recomp::InputDevice::Controller, p);
+        }
+
+        ports_array.push_back(port_json);
     }
 
+    config_json["ports"] = ports_array;
     return save_json_with_backups(path, config_json);
 }
 
-bool load_input_device_from_json(const nlohmann::json& config_json, recomp::InputDevice device, const std::string& key) {
+bool load_input_device_from_json(const nlohmann::json& config_json, recomp::InputDevice device, const std::string& key, int port) {
     // Check if the json object for the given key exists.
     auto find_it = config_json.find(key);
     if (find_it == config_json.end()) {
@@ -405,6 +435,10 @@ bool load_input_device_from_json(const nlohmann::json& config_json, recomp::Inpu
     }
 
     const nlohmann::json& mappings_json = *find_it;
+
+    const recomp::DefaultN64Mappings& defaults = (device == recomp::InputDevice::Keyboard)
+        ? recomp::get_default_keyboard_mappings_for_port(port)
+        : recomp::default_n64_controller_mappings;
 
     for (size_t i = 0; i < recomp::get_num_inputs(); i++) {
         recomp::GameInput cur_input = static_cast<recomp::GameInput>(i);
@@ -416,12 +450,8 @@ bool load_input_device_from_json(const nlohmann::json& config_json, recomp::Inpu
             assign_mapping(
                 device,
                 cur_input,
-                recomp::get_default_mapping_for_input(
-                    device == recomp::InputDevice::Keyboard ?
-                    recomp::default_n64_keyboard_mappings :
-                    recomp::default_n64_controller_mappings,
-                    cur_input
-                )
+                recomp::get_default_mapping_for_input(defaults, cur_input),
+                port
             );
             continue;
         }
@@ -431,7 +461,7 @@ bool load_input_device_from_json(const nlohmann::json& config_json, recomp::Inpu
         for (size_t binding_index = 0; binding_index < std::min(recomp::bindings_per_input, input_json.size()); binding_index++) {
             recomp::InputField cur_field{};
             recomp::from_json(input_json[binding_index], cur_field);
-            recomp::set_input_binding(cur_input, binding_index, device, cur_field);
+            recomp::set_input_binding(cur_input, binding_index, device, cur_field, port);
         }
     }
 
@@ -444,13 +474,48 @@ bool load_controls_config(const std::filesystem::path& path) {
         return false;
     }
 
-    if (!load_input_device_from_json(config_json, recomp::InputDevice::Keyboard, "keyboard")) {
-        assign_all_mappings(recomp::InputDevice::Keyboard, recomp::default_n64_keyboard_mappings);
+    // Check for new per-port format
+    auto ports_it = config_json.find("ports");
+    if (ports_it != config_json.end() && ports_it->is_array()) {
+        const nlohmann::json& ports_array = *ports_it;
+        for (int p = 0; p < recomp::max_ports && p < (int)ports_array.size(); p++) {
+            const nlohmann::json& port_json = ports_array[p];
+
+            // Load mode
+            recomp::ControllerPortMode mode = from_or_default(port_json, "mode",
+                p == 0 ? recomp::ControllerPortMode::Keyboard : recomp::ControllerPortMode::Off);
+            recomp::set_port_mode(p, mode);
+
+            // Load bindings
+            if (!load_input_device_from_json(port_json, recomp::InputDevice::Keyboard, "keyboard", p)) {
+                assign_all_mappings(recomp::InputDevice::Keyboard, recomp::get_default_keyboard_mappings_for_port(p), p);
+            }
+            if (!load_input_device_from_json(port_json, recomp::InputDevice::Controller, "controller", p)) {
+                assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings, p);
+            }
+        }
+        return true;
     }
 
-    if (!load_input_device_from_json(config_json, recomp::InputDevice::Controller, "controller")) {
-        assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings);
+    // Backward compatibility: old flat format -> load as port 0
+    recomp::set_port_mode(0, recomp::ControllerPortMode::Keyboard);
+    for (int p = 1; p < recomp::max_ports; p++) {
+        recomp::set_port_mode(p, recomp::ControllerPortMode::Off);
     }
+
+    if (!load_input_device_from_json(config_json, recomp::InputDevice::Keyboard, "keyboard", 0)) {
+        assign_all_mappings(recomp::InputDevice::Keyboard, recomp::default_n64_keyboard_mappings, 0);
+    }
+    if (!load_input_device_from_json(config_json, recomp::InputDevice::Controller, "controller", 0)) {
+        assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings, 0);
+    }
+
+    // Set defaults for ports 1-3
+    for (int p = 1; p < recomp::max_ports; p++) {
+        assign_all_mappings(recomp::InputDevice::Keyboard, recomp::get_default_keyboard_mappings_for_port(p), p);
+        assign_all_mappings(recomp::InputDevice::Controller, recomp::default_n64_controller_mappings, p);
+    }
+
     return true;
 }
 

--- a/src/game/controls.cpp
+++ b/src/game/controls.cpp
@@ -94,33 +94,56 @@ bool recomp::get_n64_input(int controller_num, uint16_t* buttons_out, float* x_o
     float cur_x = 0.0f;
     float cur_y = 0.0f;
 
-    if (controller_num != 0) {
+    if (controller_num < 0 || controller_num >= recomp::max_ports) {
+        *buttons_out = 0;
+        *x_out = 0.0f;
+        *y_out = 0.0f;
+        return false;
+    }
+
+    recomp::ControllerPortMode mode = recomp::get_port_mode(controller_num);
+    if (mode == recomp::ControllerPortMode::Off) {
+        *buttons_out = 0;
+        *x_out = 0.0f;
+        *y_out = 0.0f;
         return false;
     }
 
     if (!recomp::game_input_disabled()) {
-        input_mapping_array& kb_mappings = keyboard_input_mappings[0];
-        input_mapping_array& ct_mappings = controller_input_mappings[0];
+        input_mapping_array& kb_mappings = keyboard_input_mappings[controller_num];
+        input_mapping_array& ct_mappings = controller_input_mappings[controller_num];
 
-        for (size_t i = 0; i < n64_button_values.size(); i++) {
-            size_t input_index = (size_t)GameInput::N64_BUTTON_START + i;
-            cur_buttons |= recomp::get_input_digital(kb_mappings[input_index]) ? n64_button_values[i] : 0;
-            cur_buttons |= recomp::get_input_digital(ct_mappings[input_index]) ? n64_button_values[i] : 0;
+        if (mode == recomp::ControllerPortMode::Keyboard) {
+            // Keyboard mode: read only keyboard bindings for this port
+            for (size_t i = 0; i < n64_button_values.size(); i++) {
+                size_t input_index = (size_t)GameInput::N64_BUTTON_START + i;
+                cur_buttons |= recomp::get_input_digital(kb_mappings[input_index]) ? n64_button_values[i] : 0;
+            }
+
+            cur_x = recomp::get_input_analog(kb_mappings[(size_t)GameInput::X_AXIS_POS])
+                    - recomp::get_input_analog(kb_mappings[(size_t)GameInput::X_AXIS_NEG]);
+
+            cur_y = recomp::get_input_analog(kb_mappings[(size_t)GameInput::Y_AXIS_POS])
+                    - recomp::get_input_analog(kb_mappings[(size_t)GameInput::Y_AXIS_NEG]);
         }
+        else if (mode == recomp::ControllerPortMode::Controller) {
+            // Controller mode: read only the gamepad assigned to this port
+            for (size_t i = 0; i < n64_button_values.size(); i++) {
+                size_t input_index = (size_t)GameInput::N64_BUTTON_START + i;
+                cur_buttons |= recomp::get_input_digital_port(ct_mappings[input_index], controller_num) ? n64_button_values[i] : 0;
+            }
 
-        float joystick_x = recomp::get_input_analog(ct_mappings[(size_t)GameInput::X_AXIS_POS])
-                        - recomp::get_input_analog(ct_mappings[(size_t)GameInput::X_AXIS_NEG]);
+            float joystick_x = recomp::get_input_analog_port(ct_mappings[(size_t)GameInput::X_AXIS_POS], controller_num)
+                            - recomp::get_input_analog_port(ct_mappings[(size_t)GameInput::X_AXIS_NEG], controller_num);
 
-        float joystick_y = recomp::get_input_analog(ct_mappings[(size_t)GameInput::Y_AXIS_POS])
-                        - recomp::get_input_analog(ct_mappings[(size_t)GameInput::Y_AXIS_NEG]);
+            float joystick_y = recomp::get_input_analog_port(ct_mappings[(size_t)GameInput::Y_AXIS_POS], controller_num)
+                            - recomp::get_input_analog_port(ct_mappings[(size_t)GameInput::Y_AXIS_NEG], controller_num);
 
-        recomp::apply_joystick_deadzone(joystick_x, joystick_y, &joystick_x, &joystick_y);
+            recomp::apply_joystick_deadzone(joystick_x, joystick_y, &joystick_x, &joystick_y);
 
-        cur_x = recomp::get_input_analog(kb_mappings[(size_t)GameInput::X_AXIS_POS])
-                - recomp::get_input_analog(kb_mappings[(size_t)GameInput::X_AXIS_NEG]) + joystick_x;
-
-        cur_y = recomp::get_input_analog(kb_mappings[(size_t)GameInput::Y_AXIS_POS])
-                - recomp::get_input_analog(kb_mappings[(size_t)GameInput::Y_AXIS_NEG]) + joystick_y;
+            cur_x = joystick_x;
+            cur_y = joystick_y;
+        }
     }
 
     *buttons_out = cur_buttons;

--- a/src/game/controls.cpp
+++ b/src/game/controls.cpp
@@ -59,6 +59,7 @@ recomp::InputField& recomp::get_input_binding(GameInput input, size_t binding_in
 }
 
 recomp::InputField& recomp::get_input_binding(GameInput input, size_t binding_index, recomp::InputDevice device, int port) {
+    if (port < 0 || port >= recomp::max_ports) port = 0;
     input_mapping_array& device_mappings = (device == recomp::InputDevice::Controller)
         ? controller_input_mappings[port]
         : keyboard_input_mappings[port];
@@ -79,6 +80,7 @@ void recomp::set_input_binding(recomp::GameInput input, size_t binding_index, re
 }
 
 void recomp::set_input_binding(recomp::GameInput input, size_t binding_index, recomp::InputDevice device, recomp::InputField value, int port) {
+    if (port < 0 || port >= recomp::max_ports) port = 0;
     input_mapping_array& device_mappings = (device == recomp::InputDevice::Controller)
         ? controller_input_mappings[port]
         : keyboard_input_mappings[port];

--- a/src/game/controls.cpp
+++ b/src/game/controls.cpp
@@ -5,10 +5,11 @@
 #include "ultramodern/ultramodern.hpp"
 
 // Arrays that hold the mappings for every input for keyboard and controller respectively.
+// Now per-port: index by [port][input][binding].
 using input_mapping = std::array<recomp::InputField, recomp::bindings_per_input>;
 using input_mapping_array = std::array<input_mapping, static_cast<size_t>(recomp::GameInput::COUNT)>;
-static input_mapping_array keyboard_input_mappings{};
-static input_mapping_array controller_input_mappings{};
+static std::array<input_mapping_array, recomp::max_ports> keyboard_input_mappings{};
+static std::array<input_mapping_array, recomp::max_ports> controller_input_mappings{};
 
 // Make the button value array, which maps a button index to its bit field.
 #define DEFINE_INPUT(name, value, readable) uint16_t(value##u),
@@ -52,9 +53,15 @@ recomp::GameInput recomp::get_input_from_enum_name(const std::string_view enum_n
     return static_cast<recomp::GameInput>(find_it - input_enum_names.begin());
 }
 
-// Due to an RmlUi limitation this can't be const. Ideally it would return a const reference or even just a straight up copy.
+// Backward-compat overload: port 0
 recomp::InputField& recomp::get_input_binding(GameInput input, size_t binding_index, recomp::InputDevice device) {
-    input_mapping_array& device_mappings = (device == recomp::InputDevice::Controller) ?  controller_input_mappings : keyboard_input_mappings;
+    return get_input_binding(input, binding_index, device, 0);
+}
+
+recomp::InputField& recomp::get_input_binding(GameInput input, size_t binding_index, recomp::InputDevice device, int port) {
+    input_mapping_array& device_mappings = (device == recomp::InputDevice::Controller)
+        ? controller_input_mappings[port]
+        : keyboard_input_mappings[port];
     input_mapping& cur_input_mapping = device_mappings.at(static_cast<size_t>(input));
 
     if (binding_index < cur_input_mapping.size()) {
@@ -66,8 +73,15 @@ recomp::InputField& recomp::get_input_binding(GameInput input, size_t binding_in
     }
 }
 
+// Backward-compat overload: port 0
 void recomp::set_input_binding(recomp::GameInput input, size_t binding_index, recomp::InputDevice device, recomp::InputField value) {
-    input_mapping_array& device_mappings = (device == recomp::InputDevice::Controller) ?  controller_input_mappings : keyboard_input_mappings;
+    set_input_binding(input, binding_index, device, value, 0);
+}
+
+void recomp::set_input_binding(recomp::GameInput input, size_t binding_index, recomp::InputDevice device, recomp::InputField value, int port) {
+    input_mapping_array& device_mappings = (device == recomp::InputDevice::Controller)
+        ? controller_input_mappings[port]
+        : keyboard_input_mappings[port];
     input_mapping& cur_input_mapping = device_mappings.at(static_cast<size_t>(input));
 
     if (binding_index < cur_input_mapping.size()) {
@@ -79,33 +93,34 @@ bool recomp::get_n64_input(int controller_num, uint16_t* buttons_out, float* x_o
     uint16_t cur_buttons = 0;
     float cur_x = 0.0f;
     float cur_y = 0.0f;
-    
+
     if (controller_num != 0) {
         return false;
     }
 
     if (!recomp::game_input_disabled()) {
+        input_mapping_array& kb_mappings = keyboard_input_mappings[0];
+        input_mapping_array& ct_mappings = controller_input_mappings[0];
+
         for (size_t i = 0; i < n64_button_values.size(); i++) {
             size_t input_index = (size_t)GameInput::N64_BUTTON_START + i;
-            cur_buttons |= recomp::get_input_digital(keyboard_input_mappings[input_index]) ? n64_button_values[i] : 0;
-            cur_buttons |= recomp::get_input_digital(controller_input_mappings[input_index]) ? n64_button_values[i] : 0;
+            cur_buttons |= recomp::get_input_digital(kb_mappings[input_index]) ? n64_button_values[i] : 0;
+            cur_buttons |= recomp::get_input_digital(ct_mappings[input_index]) ? n64_button_values[i] : 0;
         }
 
-        float joystick_deadzone = recomp::get_joystick_deadzone() / 100.0f;
+        float joystick_x = recomp::get_input_analog(ct_mappings[(size_t)GameInput::X_AXIS_POS])
+                        - recomp::get_input_analog(ct_mappings[(size_t)GameInput::X_AXIS_NEG]);
 
-        float joystick_x = recomp::get_input_analog(controller_input_mappings[(size_t)GameInput::X_AXIS_POS])
-                        - recomp::get_input_analog(controller_input_mappings[(size_t)GameInput::X_AXIS_NEG]);
-
-        float joystick_y = recomp::get_input_analog(controller_input_mappings[(size_t)GameInput::Y_AXIS_POS])
-                        - recomp::get_input_analog(controller_input_mappings[(size_t)GameInput::Y_AXIS_NEG]);
+        float joystick_y = recomp::get_input_analog(ct_mappings[(size_t)GameInput::Y_AXIS_POS])
+                        - recomp::get_input_analog(ct_mappings[(size_t)GameInput::Y_AXIS_NEG]);
 
         recomp::apply_joystick_deadzone(joystick_x, joystick_y, &joystick_x, &joystick_y);
 
-        cur_x = recomp::get_input_analog(keyboard_input_mappings[(size_t)GameInput::X_AXIS_POS])
-                - recomp::get_input_analog(keyboard_input_mappings[(size_t)GameInput::X_AXIS_NEG]) + joystick_x;
+        cur_x = recomp::get_input_analog(kb_mappings[(size_t)GameInput::X_AXIS_POS])
+                - recomp::get_input_analog(kb_mappings[(size_t)GameInput::X_AXIS_NEG]) + joystick_x;
 
-        cur_y = recomp::get_input_analog(keyboard_input_mappings[(size_t)GameInput::Y_AXIS_POS])
-                - recomp::get_input_analog(keyboard_input_mappings[(size_t)GameInput::Y_AXIS_NEG]) + joystick_y;
+        cur_y = recomp::get_input_analog(kb_mappings[(size_t)GameInput::Y_AXIS_POS])
+                - recomp::get_input_analog(kb_mappings[(size_t)GameInput::Y_AXIS_NEG]) + joystick_y;
     }
 
     *buttons_out = cur_buttons;

--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -23,6 +23,28 @@ struct ControllerState {
     };
 };
 
+// Per-port mode state
+static std::array<recomp::ControllerPortMode, recomp::max_ports> port_modes = {
+    recomp::ControllerPortMode::Keyboard,
+    recomp::ControllerPortMode::Off,
+    recomp::ControllerPortMode::Off,
+    recomp::ControllerPortMode::Off,
+};
+
+recomp::ControllerPortMode recomp::get_port_mode(int port) {
+    if (port < 0 || port >= recomp::max_ports) return recomp::ControllerPortMode::Off;
+    return port_modes[port];
+}
+
+void recomp::set_port_mode(int port, recomp::ControllerPortMode mode) {
+    if (port < 0 || port >= recomp::max_ports) return;
+    port_modes[port] = mode;
+}
+
+int recomp::get_port_count() {
+    return recomp::max_ports;
+}
+
 static struct {
     const Uint8* keys = nullptr;
     SDL_Keymod keymod = SDL_Keymod::KMOD_NONE;

--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -701,6 +701,18 @@ bool controller_button_state(int32_t input_id) {
     return false;
 }
 
+// Per-port version: reads only the assigned gamepad for the given port
+bool controller_button_state_port(int32_t input_id, int port) {
+    if (input_id >= 0 && input_id < SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_MAX) {
+        SDL_GameControllerButton button = (SDL_GameControllerButton)input_id;
+        SDL_GameController* controller = InputState.port_controllers[port];
+        if (controller != nullptr) {
+            return SDL_GameControllerGetButton(controller, button) != 0;
+        }
+    }
+    return false;
+}
+
 static std::atomic_bool right_analog_suppressed = false;
 
 float controller_axis_state(int32_t input_id, bool allow_suppression) {
@@ -727,6 +739,32 @@ float controller_axis_state(int32_t input_id, bool allow_suppression) {
         }
 
         return std::clamp(ret, 0.0f, 1.0f);
+    }
+    return false;
+}
+
+// Per-port version: reads only the assigned gamepad for the given port
+float controller_axis_state_port(int32_t input_id, bool allow_suppression, int port) {
+    if (abs(input_id) - 1 < SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_MAX) {
+        SDL_GameControllerAxis axis = (SDL_GameControllerAxis)(abs(input_id) - 1);
+        bool negative_range = input_id < 0;
+        float ret = 0.0f;
+
+        SDL_GameController* controller = InputState.port_controllers[port];
+        if (controller != nullptr) {
+            float cur_val = SDL_GameControllerGetAxis(controller, axis) * (1/32768.0f);
+            if (negative_range) {
+                cur_val = -cur_val;
+            }
+
+            if (allow_suppression && right_analog_suppressed.load() &&
+                (axis == SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_RIGHTX || axis == SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_RIGHTY)) {
+                cur_val = 0;
+            }
+            ret = std::clamp(cur_val, 0.0f, 1.0f);
+        }
+
+        return ret;
     }
     return false;
 }
@@ -788,6 +826,65 @@ bool recomp::get_input_digital(const std::span<const recomp::InputField> fields)
     bool ret = 0;
     for (const auto& field : fields) {
         ret |= get_input_digital(field);
+    }
+    return ret;
+}
+
+// Per-port versions: for controller inputs, read only from the port's assigned gamepad
+float recomp::get_input_analog_port(const recomp::InputField& field, int port) {
+    switch ((InputType)field.input_type) {
+    case InputType::Keyboard:
+        if (InputState.keys && field.input_id >= 0 && field.input_id < InputState.numkeys) {
+            if (should_override_keystate(static_cast<SDL_Scancode>(field.input_id), InputState.keymod)) {
+                return 0.0f;
+            }
+            return InputState.keys[field.input_id] ? 1.0f : 0.0f;
+        }
+        return 0.0f;
+    case InputType::ControllerDigital:
+        return controller_button_state_port(field.input_id, port) ? 1.0f : 0.0f;
+    case InputType::ControllerAnalog:
+        return controller_axis_state_port(field.input_id, true, port);
+    case InputType::Mouse:
+        return 0.0f;
+    case InputType::None:
+        return false;
+    }
+}
+
+float recomp::get_input_analog_port(const std::span<const recomp::InputField> fields, int port) {
+    float ret = 0.0f;
+    for (const auto& field : fields) {
+        ret += get_input_analog_port(field, port);
+    }
+    return std::clamp(ret, 0.0f, 1.0f);
+}
+
+bool recomp::get_input_digital_port(const recomp::InputField& field, int port) {
+    switch ((InputType)field.input_type) {
+    case InputType::Keyboard:
+        if (InputState.keys && field.input_id >= 0 && field.input_id < InputState.numkeys) {
+            if (should_override_keystate(static_cast<SDL_Scancode>(field.input_id), InputState.keymod)) {
+                return false;
+            }
+            return InputState.keys[field.input_id] != 0;
+        }
+        return false;
+    case InputType::ControllerDigital:
+        return controller_button_state_port(field.input_id, port);
+    case InputType::ControllerAnalog:
+        return controller_axis_state_port(field.input_id, true, port) >= axis_threshold;
+    case InputType::Mouse:
+        return false;
+    case InputType::None:
+        return false;
+    }
+}
+
+bool recomp::get_input_digital_port(const std::span<const recomp::InputField> fields, int port) {
+    bool ret = 0;
+    for (const auto& field : fields) {
+        ret |= get_input_digital_port(field, port);
     }
     return ret;
 }

--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -53,15 +53,20 @@ static struct {
     std::mutex cur_controllers_mutex;
     std::vector<SDL_GameController*> cur_controllers{};
     std::unordered_map<SDL_JoystickID, ControllerState> controller_states;
-    
+
+    // Per-port controller assignment
+    std::array<SDL_JoystickID, recomp::max_ports> port_controller_ids = {-1, -1, -1, -1};
+    std::array<SDL_GameController*, recomp::max_ports> port_controllers = {nullptr, nullptr, nullptr, nullptr};
+
     std::array<float, 2> rotation_delta{};
     std::array<float, 2> mouse_delta{};
     std::mutex pending_input_mutex;
     std::array<float, 2> pending_rotation_delta{};
     std::array<float, 2> pending_mouse_delta{};
 
-    float cur_rumble;
-    bool rumble_active;
+    // Per-port rumble state
+    std::array<float, recomp::max_ports> cur_rumble = {0.0f, 0.0f, 0.0f, 0.0f};
+    std::array<bool, recomp::max_ports> rumble_active = {false, false, false, false};
 } InputState;
 
 static struct {
@@ -158,13 +163,24 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
             SDL_GameController* controller = SDL_GameControllerOpen(controller_event->which);
             printf("Controller added: %d\n", controller_event->which);
             if (controller != nullptr) {
-                printf("  Instance ID: %d\n", SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller)));
-                ControllerState& state = InputState.controller_states[SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller))];
+                SDL_JoystickID instance_id = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller));
+                printf("  Instance ID: %d\n", instance_id);
+                ControllerState& state = InputState.controller_states[instance_id];
                 state.controller = controller;
 
                 if (SDL_GameControllerHasSensor(controller, SDL_SensorType::SDL_SENSOR_GYRO) && SDL_GameControllerHasSensor(controller, SDL_SensorType::SDL_SENSOR_ACCEL)) {
                     SDL_GameControllerSetSensorEnabled(controller, SDL_SensorType::SDL_SENSOR_GYRO, SDL_TRUE);
                     SDL_GameControllerSetSensorEnabled(controller, SDL_SensorType::SDL_SENSOR_ACCEL, SDL_TRUE);
+                }
+
+                // Assign to first port with mode=Controller and no assignment
+                for (int p = 0; p < recomp::max_ports; p++) {
+                    if (port_modes[p] == recomp::ControllerPortMode::Controller && InputState.port_controllers[p] == nullptr) {
+                        InputState.port_controller_ids[p] = instance_id;
+                        InputState.port_controllers[p] = controller;
+                        printf("  Assigned to port %d\n", p);
+                        break;
+                    }
                 }
             }
         }
@@ -173,6 +189,17 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
         {
             SDL_ControllerDeviceEvent* controller_event = &event->cdevice;
             printf("Controller removed: %d\n", controller_event->which);
+
+            // Clear port assignment for this controller
+            for (int p = 0; p < recomp::max_ports; p++) {
+                if (InputState.port_controller_ids[p] == controller_event->which) {
+                    InputState.port_controller_ids[p] = -1;
+                    InputState.port_controllers[p] = nullptr;
+                    printf("  Cleared port %d assignment\n", p);
+                    break;
+                }
+            }
+
             InputState.controller_states.erase(controller_event->which);
         }
         break;
@@ -485,6 +512,71 @@ const recomp::DefaultN64Mappings recomp::default_n64_controller_mappings = {
     }
 };
 
+// Port 1 default keyboard mappings: arrow keys + nearby keys
+const recomp::DefaultN64Mappings default_n64_keyboard_mappings_p2 = {
+    .a = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_RSHIFT}
+    },
+    .b = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_RCTRL}
+    },
+    .l = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_PAGEUP}
+    },
+    .r = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_PAGEDOWN}
+    },
+    .z = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_RALT}
+    },
+    .start = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_KP_ENTER}
+    },
+    .c_left = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_KP_4}
+    },
+    .c_right = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_KP_6}
+    },
+    .c_up = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_KP_8}
+    },
+    .c_down = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_KP_2}
+    },
+    .dpad_left = {},
+    .dpad_right = {},
+    .dpad_up = {},
+    .dpad_down = {},
+    .analog_left = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_LEFT}
+    },
+    .analog_right = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_RIGHT}
+    },
+    .analog_up = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_UP}
+    },
+    .analog_down = {
+        {.input_type = (uint32_t)InputType::Keyboard, .input_id = SDL_SCANCODE_DOWN}
+    },
+    .toggle_menu = {},
+    .accept_menu = {},
+    .apply_menu = {}
+};
+
+const recomp::DefaultN64Mappings& recomp::get_default_keyboard_mappings_for_port(int port) {
+    switch (port) {
+        case 0: return recomp::default_n64_keyboard_mappings;
+        case 1: return default_n64_keyboard_mappings_p2;
+        default: {
+            // Ports 2-3: empty defaults
+            static const recomp::DefaultN64Mappings empty{};
+            return empty;
+        }
+    }
+}
+
 void recomp::poll_inputs() {
     InputState.keys = SDL_GetKeyboardState(&InputState.numkeys);
     InputState.keymod = SDL_GetModState();
@@ -533,24 +625,35 @@ void recomp::poll_inputs() {
 }
 
 void recomp::set_rumble(int controller_num, bool on) {
-    if (controller_num == 0) {
-        InputState.rumble_active = on;
+    if (controller_num >= 0 && controller_num < recomp::max_ports) {
+        InputState.rumble_active[controller_num] = on;
     }
 }
 
 ultramodern::input::connected_device_info_t recomp::get_connected_device_info(int controller_num) {
-    switch (controller_num) {
-        case 0:
+    if (controller_num >= 0 && controller_num < recomp::max_ports) {
+        if (port_modes[controller_num] != recomp::ControllerPortMode::Off) {
             return ultramodern::input::connected_device_info_t {
                 .connected_device = ultramodern::input::Device::Controller,
                 .connected_pak = ultramodern::input::Pak::RumblePak,
             };
+        }
     }
 
     return ultramodern::input::connected_device_info_t {
         .connected_device = ultramodern::input::Device::None,
         .connected_pak = ultramodern::input::Pak::None,
     };
+}
+
+std::string recomp::get_port_controller_name(int port) {
+    if (port >= 0 && port < recomp::max_ports && InputState.port_controllers[port] != nullptr) {
+        const char* name = SDL_GameControllerName(InputState.port_controllers[port]);
+        if (name != nullptr) {
+            return std::string(name);
+        }
+    }
+    return "None";
 }
 
 static float smoothstep(float from, float to, float amount) {
@@ -561,21 +664,22 @@ static float smoothstep(float from, float to, float amount) {
 // Update rumble to attempt to mimic the way n64 rumble ramps up and falls off
 void recomp::update_rumble() {
     // Note: values are not accurate! just approximations based on feel
-    if (InputState.rumble_active) {
-        InputState.cur_rumble += 0.17f;
-        if (InputState.cur_rumble > 1) InputState.cur_rumble = 1;
-    } else {
-        InputState.cur_rumble *= 0.92f;
-        InputState.cur_rumble -= 0.01f;
-        if (InputState.cur_rumble < 0) InputState.cur_rumble = 0;
-    }
-    float smooth_rumble = smoothstep(0, 1, InputState.cur_rumble);
-
-    uint16_t rumble_strength = smooth_rumble * (recomp::get_rumble_strength() * 0xFFFF / 100);
     uint32_t duration = 1000000; // Dummy duration value that lasts long enough to matter as the game will reset rumble on its own.
-    {
-        std::lock_guard lock{ InputState.cur_controllers_mutex };
-        for (const auto& controller : InputState.cur_controllers) {
+    for (int p = 0; p < recomp::max_ports; p++) {
+        if (InputState.rumble_active[p]) {
+            InputState.cur_rumble[p] += 0.17f;
+            if (InputState.cur_rumble[p] > 1) InputState.cur_rumble[p] = 1;
+        } else {
+            InputState.cur_rumble[p] *= 0.92f;
+            InputState.cur_rumble[p] -= 0.01f;
+            if (InputState.cur_rumble[p] < 0) InputState.cur_rumble[p] = 0;
+        }
+        float smooth_rumble = smoothstep(0, 1, InputState.cur_rumble[p]);
+        uint16_t rumble_strength = smooth_rumble * (recomp::get_rumble_strength() * 0xFFFF / 100);
+
+        // Apply rumble only to the assigned controller for this port
+        SDL_GameController* controller = InputState.port_controllers[p];
+        if (controller != nullptr) {
             SDL_GameControllerRumble(controller, 0, rumble_strength, duration);
         }
     }

--- a/src/game/input.cpp
+++ b/src/game/input.cpp
@@ -24,7 +24,7 @@ struct ControllerState {
 };
 
 // Per-port mode state
-static std::array<recomp::ControllerPortMode, recomp::max_ports> port_modes = {
+static std::array<std::atomic<recomp::ControllerPortMode>, recomp::max_ports> port_modes = {
     recomp::ControllerPortMode::Keyboard,
     recomp::ControllerPortMode::Off,
     recomp::ControllerPortMode::Off,
@@ -33,12 +33,12 @@ static std::array<recomp::ControllerPortMode, recomp::max_ports> port_modes = {
 
 recomp::ControllerPortMode recomp::get_port_mode(int port) {
     if (port < 0 || port >= recomp::max_ports) return recomp::ControllerPortMode::Off;
-    return port_modes[port];
+    return port_modes[port].load();
 }
 
 void recomp::set_port_mode(int port, recomp::ControllerPortMode mode) {
     if (port < 0 || port >= recomp::max_ports) return;
-    port_modes[port] = mode;
+    port_modes[port].store(mode);
 }
 
 int recomp::get_port_count() {
@@ -174,12 +174,15 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
                 }
 
                 // Assign to first port with mode=Controller and no assignment
-                for (int p = 0; p < recomp::max_ports; p++) {
-                    if (port_modes[p] == recomp::ControllerPortMode::Controller && InputState.port_controllers[p] == nullptr) {
-                        InputState.port_controller_ids[p] = instance_id;
-                        InputState.port_controllers[p] = controller;
-                        printf("  Assigned to port %d\n", p);
-                        break;
+                {
+                    std::lock_guard lock{InputState.cur_controllers_mutex};
+                    for (int p = 0; p < recomp::max_ports; p++) {
+                        if (port_modes[p].load() == recomp::ControllerPortMode::Controller && InputState.port_controllers[p] == nullptr) {
+                            InputState.port_controller_ids[p] = instance_id;
+                            InputState.port_controllers[p] = controller;
+                            printf("  Assigned to port %d\n", p);
+                            break;
+                        }
                     }
                 }
             }
@@ -191,12 +194,15 @@ bool sdl_event_filter(void* userdata, SDL_Event* event) {
             printf("Controller removed: %d\n", controller_event->which);
 
             // Clear port assignment for this controller
-            for (int p = 0; p < recomp::max_ports; p++) {
-                if (InputState.port_controller_ids[p] == controller_event->which) {
-                    InputState.port_controller_ids[p] = -1;
-                    InputState.port_controllers[p] = nullptr;
-                    printf("  Cleared port %d assignment\n", p);
-                    break;
+            {
+                std::lock_guard lock{InputState.cur_controllers_mutex};
+                for (int p = 0; p < recomp::max_ports; p++) {
+                    if (InputState.port_controller_ids[p] == controller_event->which) {
+                        InputState.port_controller_ids[p] = -1;
+                        InputState.port_controllers[p] = nullptr;
+                        printf("  Cleared port %d assignment\n", p);
+                        break;
+                    }
                 }
             }
 
@@ -632,7 +638,7 @@ void recomp::set_rumble(int controller_num, bool on) {
 
 ultramodern::input::connected_device_info_t recomp::get_connected_device_info(int controller_num) {
     if (controller_num >= 0 && controller_num < recomp::max_ports) {
-        if (port_modes[controller_num] != recomp::ControllerPortMode::Off) {
+        if (port_modes[controller_num].load() != recomp::ControllerPortMode::Off) {
             return ultramodern::input::connected_device_info_t {
                 .connected_device = ultramodern::input::Device::Controller,
                 .connected_pak = ultramodern::input::Pak::RumblePak,
@@ -654,6 +660,63 @@ std::string recomp::get_port_controller_name(int port) {
         }
     }
     return "None";
+}
+
+// Build a snapshot of all connected controllers from controller_states
+static std::vector<std::pair<SDL_JoystickID, SDL_GameController*>> get_all_controllers_snapshot() {
+    std::vector<std::pair<SDL_JoystickID, SDL_GameController*>> result;
+    for (const auto& [id, state] : InputState.controller_states) {
+        if (state.controller != nullptr) {
+            result.emplace_back(id, state.controller);
+        }
+    }
+    return result;
+}
+
+std::vector<std::string> recomp::get_connected_controller_names() {
+    std::lock_guard lock{InputState.cur_controllers_mutex};
+    auto controllers = get_all_controllers_snapshot();
+    std::vector<std::string> names;
+    for (auto& [id, controller] : controllers) {
+        const char* name = SDL_GameControllerName(controller);
+        names.emplace_back(name ? name : "Unknown Controller");
+    }
+    return names;
+}
+
+int recomp::get_port_controller_index(int port) {
+    std::lock_guard lock{InputState.cur_controllers_mutex};
+    if (port < 0 || port >= recomp::max_ports || InputState.port_controllers[port] == nullptr) {
+        return -1;
+    }
+    auto controllers = get_all_controllers_snapshot();
+    for (size_t i = 0; i < controllers.size(); i++) {
+        if (controllers[i].second == InputState.port_controllers[port]) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+void recomp::assign_controller_to_port(int port, int controller_index) {
+    std::lock_guard lock{InputState.cur_controllers_mutex};
+    if (port < 0 || port >= recomp::max_ports) return;
+    auto controllers = get_all_controllers_snapshot();
+    if (controller_index < 0 || controller_index >= static_cast<int>(controllers.size())) {
+        InputState.port_controllers[port] = nullptr;
+        InputState.port_controller_ids[port] = -1;
+        return;
+    }
+    // Clear this controller from any other port first
+    SDL_JoystickID new_id = controllers[controller_index].first;
+    for (int p = 0; p < recomp::max_ports; p++) {
+        if (p != port && InputState.port_controller_ids[p] == new_id) {
+            InputState.port_controllers[p] = nullptr;
+            InputState.port_controller_ids[p] = -1;
+        }
+    }
+    InputState.port_controllers[port] = controllers[controller_index].second;
+    InputState.port_controller_ids[port] = new_id;
 }
 
 static float smoothstep(float from, float to, float amount) {
@@ -703,6 +766,7 @@ bool controller_button_state(int32_t input_id) {
 
 // Per-port version: reads only the assigned gamepad for the given port
 bool controller_button_state_port(int32_t input_id, int port) {
+    if (port < 0 || port >= recomp::max_ports) return false;
     if (input_id >= 0 && input_id < SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_MAX) {
         SDL_GameControllerButton button = (SDL_GameControllerButton)input_id;
         SDL_GameController* controller = InputState.port_controllers[port];
@@ -745,6 +809,7 @@ float controller_axis_state(int32_t input_id, bool allow_suppression) {
 
 // Per-port version: reads only the assigned gamepad for the given port
 float controller_axis_state_port(int32_t input_id, bool allow_suppression, int port) {
+    if (port < 0 || port >= recomp::max_ports) return 0.0f;
     if (abs(input_id) - 1 < SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_MAX) {
         SDL_GameControllerAxis axis = (SDL_GameControllerAxis)(abs(input_id) - 1);
         bool negative_range = input_id < 0;

--- a/src/ui/ui_config.cpp
+++ b/src/ui/ui_config.cpp
@@ -96,6 +96,19 @@ static int scanned_input_index = -1;
 static int focused_input_index = -1;
 static int focused_config_option_index = -1;
 static int selected_port = 0;
+static int port_mode_index = 0; // 0=Off, 1=Keyboard, 2=Controller
+static int port_controller_index = -1;
+static std::vector<std::string> connected_controller_names;
+
+static void refresh_controller_list() {
+    connected_controller_names = recomp::get_connected_controller_names();
+    if (connected_controller_names.empty()) {
+        connected_controller_names.push_back("No controller detected");
+        port_controller_index = 0;
+    } else {
+        port_controller_index = recomp::get_port_controller_index(selected_port);
+    }
+}
 
 static bool msaa2x_supported = false;
 static bool msaa4x_supported = false;
@@ -499,6 +512,12 @@ class ConfigTabsetListener : public Rml::EventListener {
     void ProcessEvent(Rml::Event& event) override {
         if (event.GetId() == Rml::EventId::Tabchange) {
             int tab_index = event.GetParameter<int>("tab_index", 0);
+            // Refresh controller list when switching to controls tab
+            if (tab_index == recompui::config_tab_to_index(recompui::ConfigTab::Controls)) {
+                refresh_controller_list();
+                controls_model_handle.DirtyVariable("connected_controller_names");
+                controls_model_handle.DirtyVariable("port_controller_index");
+            }
             bool in_mod_tab = (tab_index == recompui::config_tab_to_index(recompui::ConfigTab::Mods));
             if (in_mod_tab) {
                 recompui::set_config_tabset_mod_nav();
@@ -570,15 +589,16 @@ public:
                 zelda64::open_quit_game_prompt();
             });
 
-        recompui::register_event(listener, "toggle_input_device",
+        recompui::register_event(listener, "port_controller_changed",
             [](const std::string& param, Rml::Event& event) {
-                cur_device = cur_device == recomp::InputDevice::Controller
-                    ? recomp::InputDevice::Keyboard
-                    : recomp::InputDevice::Controller;
-                controls_model_handle.DirtyVariable("input_device_is_keyboard");
-                controls_model_handle.DirtyVariable("inputs");
+                int value = event.GetParameter<int>("value", -1);
+                recomp::assign_controller_to_port(selected_port, value);
+                port_controller_index = value;
+                controls_model_handle.DirtyVariable("port_controller_index");
+                controls_model_handle.DirtyVariable("assigned_controller_name");
+                zelda64::save_config();
             });
-            
+
         recompui::register_event(listener, "area_index_changed",
             [](const std::string& param, Rml::Event& event) {
                 debug_context.area_index = event.GetParameter<int>("value", 0);
@@ -747,6 +767,7 @@ public:
             return Rml::Variant{recomp::get_input_enum_name(static_cast<recomp::GameInput>(inputs.at(0).Get<size_t>()))};
         });
 
+
         constructor.BindEventCallback("set_input_binding",
             [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
                 scanned_input_index = inputs.at(0).Get<size_t>();
@@ -758,11 +779,17 @@ public:
 
         constructor.BindEventCallback("reset_input_bindings_to_defaults",
             [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
-                if (cur_device == recomp::InputDevice::Controller) {
-                    zelda64::reset_cont_input_bindings(selected_port);
-                } else {
-                    zelda64::reset_kb_input_bindings(selected_port);
+                // Reset all ports: P1 = Keyboard, P2-P4 = Off
+                recomp::set_port_mode(0, recomp::ControllerPortMode::Keyboard);
+                for (int p = 1; p < recomp::max_ports; p++) {
+                    recomp::set_port_mode(p, recomp::ControllerPortMode::Off);
                 }
+                zelda64::reset_input_bindings();
+                selected_port = 0;
+                cur_device = recomp::InputDevice::Keyboard;
+                port_mode_index = static_cast<int>(recomp::ControllerPortMode::Keyboard);
+                refresh_controller_list();
+                zelda64::save_config();
                 model_handle.DirtyAllVariables();
                 nav_help_model_handle.DirtyVariable("nav_help__accept");
                 nav_help_model_handle.DirtyVariable("nav_help__exit");
@@ -791,10 +818,16 @@ public:
         constructor.BindEventCallback("select_port",
             [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
                 selected_port = inputs.at(0).Get<int>();
-                model_handle.DirtyVariable("selected_port");
-                model_handle.DirtyVariable("port_mode");
-                model_handle.DirtyVariable("assigned_controller_name");
-                model_handle.DirtyVariable("inputs");
+                recomp::ControllerPortMode mode = recomp::get_port_mode(selected_port);
+                port_mode_index = static_cast<int>(mode);
+                // Sync cur_device with the selected port's mode
+                if (mode == recomp::ControllerPortMode::Controller) {
+                    cur_device = recomp::InputDevice::Controller;
+                } else {
+                    cur_device = recomp::InputDevice::Keyboard;
+                }
+                refresh_controller_list();
+                model_handle.DirtyAllVariables();
             });
 
         constructor.BindEventCallback("set_port_mode",
@@ -804,8 +837,23 @@ public:
                 if (mode_str == "Keyboard") mode = recomp::ControllerPortMode::Keyboard;
                 else if (mode_str == "Controller") mode = recomp::ControllerPortMode::Controller;
                 recomp::set_port_mode(selected_port, mode);
-                model_handle.DirtyVariable("port_mode");
-                model_handle.DirtyVariable("assigned_controller_name");
+                port_mode_index = static_cast<int>(mode);
+                // Sync cur_device with the new mode
+                if (mode == recomp::ControllerPortMode::Controller) {
+                    cur_device = recomp::InputDevice::Controller;
+                } else {
+                    cur_device = recomp::InputDevice::Keyboard;
+                }
+                // Auto-assign first available controller when switching to Controller mode
+                if (mode == recomp::ControllerPortMode::Controller && recomp::get_port_controller_index(selected_port) < 0) {
+                    auto names = recomp::get_connected_controller_names();
+                    if (!names.empty()) {
+                        recomp::assign_controller_to_port(selected_port, 0);
+                    }
+                }
+                refresh_controller_list();
+                model_handle.DirtyAllVariables();
+                zelda64::save_config();
             });
 
         constructor.BindEventCallback("set_input_row_focus",
@@ -911,6 +959,10 @@ public:
 
         constructor.Bind<int>("active_binding_slot", &scanned_binding_index);
         constructor.Bind<int>("selected_port", &selected_port);
+        constructor.Bind<int>("port_mode_index", &port_mode_index);
+        constructor.Bind<int>("port_controller_index", &port_controller_index);
+        constructor.RegisterArray<std::vector<std::string>>();
+        constructor.Bind("connected_controller_names", &connected_controller_names);
 
         constructor.BindFunc("port_mode", [](Rml::Variant& out) {
             recomp::ControllerPortMode mode = recomp::get_port_mode(selected_port);
@@ -926,7 +978,27 @@ public:
             out = recomp::get_port_controller_name(selected_port);
         });
 
+        constructor.BindFunc("is_multiplayer_port", [](Rml::Variant& out) {
+            out = selected_port > 0;
+        });
+
+        auto make_port_style = [](int port) -> std::string {
+            bool is_selected = (selected_port == port);
+            bool is_active = recomp::get_port_mode(port) != recomp::ControllerPortMode::Off;
+            if (is_selected) {
+                return "min-width: 48dp; opacity: 1.0;";
+            } else if (is_active) {
+                return "min-width: 48dp; opacity: 0.7;";
+            } else {
+                return "min-width: 48dp; opacity: 0.3;";
+            }
+        };
+        constructor.BindFunc("port_0_style", [make_port_style](Rml::Variant& out) { out = make_port_style(0); });
+        constructor.BindFunc("port_1_style", [make_port_style](Rml::Variant& out) { out = make_port_style(1); });
+        constructor.BindFunc("port_2_style", [make_port_style](Rml::Variant& out) { out = make_port_style(2); });
+        constructor.BindFunc("port_3_style", [make_port_style](Rml::Variant& out) { out = make_port_style(3); });
         controls_model_handle = constructor.GetModelHandle();
+        refresh_controller_list();
     }
 
     void make_nav_help_bindings(Rml::Context* context) {

--- a/src/ui/ui_config.cpp
+++ b/src/ui/ui_config.cpp
@@ -95,6 +95,7 @@ static int scanned_binding_index = -1;
 static int scanned_input_index = -1;
 static int focused_input_index = -1;
 static int focused_config_option_index = -1;
+static int selected_port = 0;
 
 static bool msaa2x_supported = false;
 static bool msaa4x_supported = false;
@@ -110,7 +111,7 @@ int recomp::get_scanned_input_index() {
 }
 
 void recomp::finish_scanning_input(recomp::InputField scanned_field) {
-    recomp::set_input_binding(static_cast<recomp::GameInput>(scanned_input_index), scanned_binding_index, cur_device, scanned_field);
+    recomp::set_input_binding(static_cast<recomp::GameInput>(scanned_input_index), scanned_binding_index, cur_device, scanned_field, selected_port);
     scanned_input_index = -1;
     scanned_binding_index = -1;
     controls_model_handle.DirtyVariable("inputs");
@@ -758,9 +759,9 @@ public:
         constructor.BindEventCallback("reset_input_bindings_to_defaults",
             [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
                 if (cur_device == recomp::InputDevice::Controller) {
-                    zelda64::reset_cont_input_bindings();
+                    zelda64::reset_cont_input_bindings(selected_port);
                 } else {
-                    zelda64::reset_kb_input_bindings();
+                    zelda64::reset_kb_input_bindings(selected_port);
                 }
                 model_handle.DirtyAllVariables();
                 nav_help_model_handle.DirtyVariable("nav_help__accept");
@@ -772,7 +773,7 @@ public:
             [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
                 recomp::GameInput input = static_cast<recomp::GameInput>(inputs.at(0).Get<size_t>());
                 for (size_t binding_index = 0; binding_index < recomp::bindings_per_input; binding_index++) {
-                    recomp::set_input_binding(input, binding_index, cur_device, recomp::InputField{});
+                    recomp::set_input_binding(input, binding_index, cur_device, recomp::InputField{}, selected_port);
                 }
                 model_handle.DirtyVariable("inputs");
                 graphics_model_handle.DirtyVariable("gfx_help__apply");
@@ -781,10 +782,30 @@ public:
         constructor.BindEventCallback("reset_single_input_binding_to_default",
             [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
                 recomp::GameInput input = static_cast<recomp::GameInput>(inputs.at(0).Get<size_t>());
-                zelda64::reset_single_input_binding(cur_device, input);
+                zelda64::reset_single_input_binding(cur_device, input, selected_port);
                 model_handle.DirtyVariable("inputs");
                 nav_help_model_handle.DirtyVariable("nav_help__accept");
                 nav_help_model_handle.DirtyVariable("nav_help__exit");
+            });
+
+        constructor.BindEventCallback("select_port",
+            [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
+                selected_port = inputs.at(0).Get<int>();
+                model_handle.DirtyVariable("selected_port");
+                model_handle.DirtyVariable("port_mode");
+                model_handle.DirtyVariable("assigned_controller_name");
+                model_handle.DirtyVariable("inputs");
+            });
+
+        constructor.BindEventCallback("set_port_mode",
+            [](Rml::DataModelHandle model_handle, Rml::Event& event, const Rml::VariantList& inputs) {
+                std::string mode_str = inputs.at(0).Get<std::string>();
+                recomp::ControllerPortMode mode = recomp::ControllerPortMode::Off;
+                if (mode_str == "Keyboard") mode = recomp::ControllerPortMode::Keyboard;
+                else if (mode_str == "Controller") mode = recomp::ControllerPortMode::Controller;
+                recomp::set_port_mode(selected_port, mode);
+                model_handle.DirtyVariable("port_mode");
+                model_handle.DirtyVariable("assigned_controller_name");
             });
 
         constructor.BindEventCallback("set_input_row_focus",
@@ -818,7 +839,7 @@ public:
             virtual int Size(void* ptr) override { return recomp::bindings_per_input; }
             virtual Rml::DataVariable Child(void* ptr, const Rml::DataAddressEntry& address) override {
                 recomp::GameInput input = static_cast<recomp::GameInput>((uintptr_t)ptr);
-                return Rml::DataVariable{&input_field_definition_instance, &recomp::get_input_binding(input, address.index, cur_device)};
+                return Rml::DataVariable{&input_field_definition_instance, &recomp::get_input_binding(input, address.index, cur_device, selected_port)};
             }
         };
         // Static instance of the InputField array variable definition to have a fixed pointer to return to RmlUi.
@@ -889,6 +910,21 @@ public:
         });
 
         constructor.Bind<int>("active_binding_slot", &scanned_binding_index);
+        constructor.Bind<int>("selected_port", &selected_port);
+
+        constructor.BindFunc("port_mode", [](Rml::Variant& out) {
+            recomp::ControllerPortMode mode = recomp::get_port_mode(selected_port);
+            switch (mode) {
+                case recomp::ControllerPortMode::Off: out = "Off"; break;
+                case recomp::ControllerPortMode::Keyboard: out = "Keyboard"; break;
+                case recomp::ControllerPortMode::Controller: out = "Controller"; break;
+                default: out = "Off"; break;
+            }
+        });
+
+        constructor.BindFunc("assigned_controller_name", [](Rml::Variant& out) {
+            out = recomp::get_port_controller_name(selected_port);
+        });
 
         controls_model_handle = constructor.GetModelHandle();
     }


### PR DESCRIPTION
Revamps the controller page to allow multiple controllers. Tested on MacOS w/ a Dualshock and keyboard (P1 & P2), worked. 

![CleanShot 2026-03-24 at 23 58 34](https://github.com/user-attachments/assets/b665c9ba-2a6c-49c9-be28-cdc81955c2ac)
